### PR TITLE
Fix paths

### DIFF
--- a/lanenet_model/lanenet_postprocess.py
+++ b/lanenet_model/lanenet_postprocess.py
@@ -22,7 +22,7 @@ from local_utils.config_utils import parse_config_utils
 
 CFG = parse_config_utils.lanenet_cfg
 
-YML_PATH="{}/dependencies/lanenet-lane-detection/data/tusimple_ipm_remap.yml".format(os.getenv("PYLOT_HOME"))
+YML_PATH="{}/dependencies/lanenet/data/tusimple_ipm_remap.yml".format(os.getenv("PYLOT_HOME"))
 
 def _morphological_process(image, kernel_size=5):
     """

--- a/local_utils/config_utils/parse_config_utils.py
+++ b/local_utils/config_utils/parse_config_utils.py
@@ -14,7 +14,7 @@ import json
 import codecs
 from ast import literal_eval
 
-CFG_PATH="{}/dependencies/lanenet-lane-detection/config/tusimple_lanenet.yaml".format(os.getenv("PYLOT_HOME"))
+CFG_PATH="{}/dependencies/lanenet/config/tusimple_lanenet.yaml".format(os.getenv("PYLOT_HOME"))
 
 
 class Config(dict):


### PR DESCRIPTION
Fixes paths referring to `$PYLOT_HOME/dependencies/lanenet-lane-detection/*` to refer to `$PYLOT_HOME/dependencies/lanenet/*` instead.